### PR TITLE
add rotation to target angles relative to field and robot, other tweaks

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,9 @@
   "recommendations": [
     "richardwillis.vscode-spotless-gradle",
     "wpilibsuite.vscode-wpilib",
-    "streetsidesoftware.code-spell-checker"
+    "streetsidesoftware.code-spell-checker",
+    "vscjava.vscode-gradle",
+    "redhat.java",
+    "sonarsource.sonarlint-vscode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,19 +1,12 @@
 {
-  "java.format.settings.url": "https://raw.githubusercontent.com/google/styleguide/gh-pages/eclipse-java-google-style.xml",
-  "java.format.settings.profile": "GoogleStyle",
+  "java.format.enabled": false,
+  "files.trimTrailingWhitespace": false,
 
   "spotlessGradle.format.enable": true,
   "spotlessGradle.diagnostics.enable": true,
   "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle",
   "editor.codeActionsOnSave": {
     "source.fixAll.spotlessGradle": true
-  },
-  "files.associations": {
-    "*.gradle": "groovy"
-  },
-  "[gradle]": {
-    "spotlessGradle.format.enable": true,
-    "editor.defaultFormatter": "richardwillis.vscode-spotless-gradle"
   },
 
   "java.configuration.updateBuildConfiguration": "automatic",

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -19,7 +19,7 @@ public final class Constants {
   public static final class Drive {
     // max voltage delivered to drivebase
     // supposedly useful to limit speed for testing
-    public static final double MAX_VOLTAGE = 8.0;
+    public static final double MAX_VOLTAGE = 12.0;
     // maximum velocity
     // FIXME measure this value experimentally
     public static final double MAX_VELOCITY_METERS_PER_SECOND =

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -34,6 +34,8 @@ public final class Constants {
         MAX_VELOCITY_METERS_PER_SECOND
             / Math.hypot(Dims.TRACKWIDTH_METERS / 2.0, Dims.WHEELBASE_METERS / 2.0);
 
+    public static final double ANGULAR_ERROR = 1.0;
+
     public static final class Dims {
       // FIXME validate with hardware
       public static final double TRACKWIDTH_METERS =

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -79,17 +79,17 @@ public class RobotContainer {
 
     Layer rightBumper = new Layer(nick::getRightBumper);
 
-    // when the bumper is held, field relative rotation
-    rightBumper.on(nick::getYButton).whenPressed(rotCommand.apply(0));
-    rightBumper.on(nick::getBButton).whenPressed(rotCommand.apply(270));
-    rightBumper.on(nick::getAButton).whenPressed(rotCommand.apply(180));
-    rightBumper.on(nick::getXButton).whenPressed(rotCommand.apply(90));
+    // when the bumper is not held, field relative rotation
+    rightBumper.off(nick::getYButton).whenPressed(rotCommand.apply(0));
+    rightBumper.off(nick::getBButton).whenPressed(rotCommand.apply(270));
+    rightBumper.off(nick::getAButton).whenPressed(rotCommand.apply(180));
+    rightBumper.off(nick::getXButton).whenPressed(rotCommand.apply(90));
 
     // otherwise, rotate robot
-    rightBumper.off(nick::getYButton).whenPressed(relRotCommand.apply(180)); // flip left
-    rightBumper.off(nick::getBButton).whenPressed(relRotCommand.apply(-90));
-    rightBumper.off(nick::getAButton).whenPressed(relRotCommand.apply(-180)); // flip right
-    rightBumper.off(nick::getXButton).whenPressed(relRotCommand.apply(90));
+    rightBumper.on(nick::getYButton).whenPressed(relRotCommand.apply(180)); // flip left
+    rightBumper.on(nick::getBButton).whenPressed(relRotCommand.apply(-90));
+    rightBumper.on(nick::getAButton).whenPressed(relRotCommand.apply(-180)); // flip right
+    rightBumper.on(nick::getXButton).whenPressed(relRotCommand.apply(90));
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -68,7 +68,7 @@ public class RobotContainer {
 
     IntFunction<RotateAngleDriveCommand> rotCommand =
         angle ->
-            new RotateAngleDriveCommand(
+            RotateAngleDriveCommand.fromRobotRelative(
                 drivebaseSubsystem, translationXSupplier, translationYSupplier, angle);
 
     new Button(nick::getYButton).whenPressed(rotCommand.apply(0));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -12,8 +12,10 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.button.Button;
 import frc.robot.commands.DefaultDriveCommand;
 import frc.robot.commands.DefenseModeCommand;
+import frc.robot.commands.RotateAngleDriveCommand;
 import frc.robot.subsystems.DrivebaseSubsystem;
 import frc.util.Util;
+import java.util.function.DoubleSupplier;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -55,8 +57,17 @@ public class RobotContainer {
    */
   private void configureButtonBindings() {
 
-    new Button(nick::getAButton).whenPressed(drivebaseSubsystem::zeroGyroscope);
+    new Button(nick::getStartButton).whenPressed(drivebaseSubsystem::zeroGyroscope);
     new Button(nick::getLeftBumper).whenHeld(new DefenseModeCommand(drivebaseSubsystem));
+    // these are flipped because the joystick is the opposite of intuition yay
+    DoubleSupplier translationXSupplier =
+        () -> (-modifyAxis(nick.getLeftY()) * Drive.MAX_VELOCITY_METERS_PER_SECOND);
+    DoubleSupplier translationYSupplier =
+        () -> (-modifyAxis(nick.getLeftX()) * Drive.MAX_VELOCITY_METERS_PER_SECOND);
+    new Button(nick::getYButton)
+        .whenPressed(
+            new RotateAngleDriveCommand(
+                drivebaseSubsystem, translationXSupplier, translationYSupplier, 0));
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -14,7 +14,7 @@ import frc.robot.commands.DefaultDriveCommand;
 import frc.robot.commands.DefenseModeCommand;
 import frc.robot.commands.RotateAngleDriveCommand;
 import frc.robot.subsystems.DrivebaseSubsystem;
-import frc.util.Util;
+import frc.util.ControllerUtil;
 import java.util.function.DoubleSupplier;
 import java.util.function.IntFunction;
 
@@ -95,7 +95,7 @@ public class RobotContainer {
    */
   private static double modifyAxis(double value) {
     // Deadband
-    value = Util.deadband(value, 0.2);
+    value = ControllerUtil.deadband(value, 0.2);
 
     // Square the axis
     value = Math.copySign(value * value, value);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -15,6 +15,7 @@ import frc.robot.commands.DefenseModeCommand;
 import frc.robot.commands.RotateAngleDriveCommand;
 import frc.robot.subsystems.DrivebaseSubsystem;
 import frc.util.ControllerUtil;
+import frc.util.Layer;
 import java.util.function.DoubleSupplier;
 import java.util.function.IntFunction;
 
@@ -71,10 +72,12 @@ public class RobotContainer {
             new RotateAngleDriveCommand(
                 drivebaseSubsystem, translationXSupplier, translationYSupplier, angle);
 
-    new Button(nick::getYButton).whenPressed(rotCommand.apply(0));
-    new Button(nick::getBButton).whenPressed(rotCommand.apply(90));
-    new Button(nick::getAButton).whenPressed(rotCommand.apply(180));
-    new Button(nick::getXButton).whenPressed(rotCommand.apply(270));
+    Layer rightBumper = new Layer(nick::getRightBumper);
+
+    rightBumper.on(nick::getYButton).whenPressed(rotCommand.apply(0));
+    rightBumper.on(nick::getBButton).whenPressed(rotCommand.apply(90));
+    rightBumper.on(nick::getAButton).whenPressed(rotCommand.apply(180));
+    rightBumper.on(nick::getXButton).whenPressed(rotCommand.apply(270));
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -79,15 +79,17 @@ public class RobotContainer {
 
     Layer rightBumper = new Layer(nick::getRightBumper);
 
+    // when the bumper is held, field relative rotation
     rightBumper.on(nick::getYButton).whenPressed(rotCommand.apply(0));
     rightBumper.on(nick::getBButton).whenPressed(rotCommand.apply(90));
     rightBumper.on(nick::getAButton).whenPressed(rotCommand.apply(180));
     rightBumper.on(nick::getXButton).whenPressed(rotCommand.apply(270));
 
-    rightBumper.off(nick::getYButton).whenPressed(relRotCommand.apply(0));
+    // otherwise, rotate robot
+    rightBumper.on(nick::getYButton).whenPressed(relRotCommand.apply(-180)); // flip left
     rightBumper.off(nick::getBButton).whenPressed(relRotCommand.apply(90));
-    rightBumper.off(nick::getAButton).whenPressed(relRotCommand.apply(180));
-    rightBumper.off(nick::getXButton).whenPressed(relRotCommand.apply(270));
+    rightBumper.off(nick::getAButton).whenPressed(relRotCommand.apply(180)); // flip right
+    rightBumper.off(nick::getXButton).whenPressed(relRotCommand.apply(-90));
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -110,7 +110,7 @@ public class RobotContainer {
    */
   private static double modifyAxis(double value) {
     // Deadband
-    value = ControllerUtil.deadband(value, 0.2);
+    value = ControllerUtil.deadband(value, 0.05);
 
     // Square the axis
     value = Math.copySign(value * value, value);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -72,12 +72,22 @@ public class RobotContainer {
             new RotateAngleDriveCommand(
                 drivebaseSubsystem, translationXSupplier, translationYSupplier, angle);
 
+    IntFunction<RotateAngleDriveCommand> relRotCommand =
+        angle ->
+            RotateAngleDriveCommand.fromRobotRelative(
+                drivebaseSubsystem, translationXSupplier, translationYSupplier, angle);
+
     Layer rightBumper = new Layer(nick::getRightBumper);
 
     rightBumper.on(nick::getYButton).whenPressed(rotCommand.apply(0));
     rightBumper.on(nick::getBButton).whenPressed(rotCommand.apply(90));
     rightBumper.on(nick::getAButton).whenPressed(rotCommand.apply(180));
     rightBumper.on(nick::getXButton).whenPressed(rotCommand.apply(270));
+
+    rightBumper.off(nick::getYButton).whenPressed(relRotCommand.apply(0));
+    rightBumper.off(nick::getBButton).whenPressed(relRotCommand.apply(90));
+    rightBumper.off(nick::getAButton).whenPressed(relRotCommand.apply(180));
+    rightBumper.off(nick::getXButton).whenPressed(relRotCommand.apply(270));
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -67,7 +67,7 @@ public class RobotContainer {
     new Button(nick::getYButton)
         .whenPressed(
             new RotateAngleDriveCommand(
-                drivebaseSubsystem, translationXSupplier, translationYSupplier, 0));
+                drivebaseSubsystem, translationXSupplier, translationYSupplier, 180));
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -71,7 +71,10 @@ public class RobotContainer {
             new RotateAngleDriveCommand(
                 drivebaseSubsystem, translationXSupplier, translationYSupplier, angle);
 
-    new Button(nick::getYButton).whenPressed(rotCommand.apply(180));
+    new Button(nick::getYButton).whenPressed(rotCommand.apply(0));
+    new Button(nick::getBButton).whenPressed(rotCommand.apply(90));
+    new Button(nick::getAButton).whenPressed(rotCommand.apply(180));
+    new Button(nick::getXButton).whenPressed(rotCommand.apply(270));
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -13,6 +13,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.button.Button;
 import frc.robot.commands.DefaultDriveCommand;
 import frc.robot.commands.DefenseModeCommand;
+import frc.robot.commands.HaltDriveCommandsCommand;
 import frc.robot.commands.RotateAngleDriveCommand;
 import frc.robot.subsystems.DrivebaseSubsystem;
 import frc.util.ControllerUtil;
@@ -94,6 +95,9 @@ public class RobotContainer {
     rightBumper.on(nick::getBButton).whenPressed(relRotCommand.apply(-90));
     rightBumper.on(nick::getAButton).whenPressed(relRotCommand.apply(-180)); // flip right
     rightBumper.on(nick::getXButton).whenPressed(relRotCommand.apply(90));
+
+    new Button(nick::getLeftStickButton)
+        .whenPressed(new HaltDriveCommandsCommand(drivebaseSubsystem));
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -118,7 +118,7 @@ public class RobotContainer {
    */
   private static double modifyAxis(double value) {
     // Deadband
-    value = ControllerUtil.deadband(value, 0.05);
+    value = ControllerUtil.deadband(value, 0.07);
 
     // Square the axis
     value = Math.copySign(value * value, value);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -16,6 +16,7 @@ import frc.robot.commands.RotateAngleDriveCommand;
 import frc.robot.subsystems.DrivebaseSubsystem;
 import frc.util.Util;
 import java.util.function.DoubleSupplier;
+import java.util.function.Function;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -64,10 +65,13 @@ public class RobotContainer {
         () -> (-modifyAxis(nick.getLeftY()) * Drive.MAX_VELOCITY_METERS_PER_SECOND);
     DoubleSupplier translationYSupplier =
         () -> (-modifyAxis(nick.getLeftX()) * Drive.MAX_VELOCITY_METERS_PER_SECOND);
-    new Button(nick::getYButton)
-        .whenPressed(
+
+    Function<Integer, Command> rotCommand =
+        (angle) ->
             new RotateAngleDriveCommand(
-                drivebaseSubsystem, translationXSupplier, translationYSupplier, 180));
+                drivebaseSubsystem, translationXSupplier, translationYSupplier, angle);
+
+    new Button(nick::getYButton).whenPressed(rotCommand.apply(180));
   }
 
   /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -81,15 +81,15 @@ public class RobotContainer {
 
     // when the bumper is held, field relative rotation
     rightBumper.on(nick::getYButton).whenPressed(rotCommand.apply(0));
-    rightBumper.on(nick::getBButton).whenPressed(rotCommand.apply(90));
+    rightBumper.on(nick::getBButton).whenPressed(rotCommand.apply(270));
     rightBumper.on(nick::getAButton).whenPressed(rotCommand.apply(180));
-    rightBumper.on(nick::getXButton).whenPressed(rotCommand.apply(270));
+    rightBumper.on(nick::getXButton).whenPressed(rotCommand.apply(90));
 
     // otherwise, rotate robot
-    rightBumper.on(nick::getYButton).whenPressed(relRotCommand.apply(-180)); // flip left
-    rightBumper.off(nick::getBButton).whenPressed(relRotCommand.apply(90));
-    rightBumper.off(nick::getAButton).whenPressed(relRotCommand.apply(180)); // flip right
-    rightBumper.off(nick::getXButton).whenPressed(relRotCommand.apply(-90));
+    rightBumper.off(nick::getYButton).whenPressed(relRotCommand.apply(180)); // flip left
+    rightBumper.off(nick::getBButton).whenPressed(relRotCommand.apply(-90));
+    rightBumper.off(nick::getAButton).whenPressed(relRotCommand.apply(-180)); // flip right
+    rightBumper.off(nick::getXButton).whenPressed(relRotCommand.apply(90));
   }
 
   /**
@@ -110,7 +110,7 @@ public class RobotContainer {
    */
   private static double modifyAxis(double value) {
     // Deadband
-    value = ControllerUtil.deadband(value, 0.2);
+    value = ControllerUtil.deadband(value, 0.05);
 
     // Square the axis
     value = Math.copySign(value * value, value);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -68,7 +68,7 @@ public class RobotContainer {
 
     IntFunction<RotateAngleDriveCommand> rotCommand =
         angle ->
-            RotateAngleDriveCommand.fromRobotRelative(
+            new RotateAngleDriveCommand(
                 drivebaseSubsystem, translationXSupplier, translationYSupplier, angle);
 
     new Button(nick::getYButton).whenPressed(rotCommand.apply(0));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -16,7 +16,7 @@ import frc.robot.commands.RotateAngleDriveCommand;
 import frc.robot.subsystems.DrivebaseSubsystem;
 import frc.util.Util;
 import java.util.function.DoubleSupplier;
-import java.util.function.Function;
+import java.util.function.IntFunction;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -66,8 +66,8 @@ public class RobotContainer {
     DoubleSupplier translationYSupplier =
         () -> (-modifyAxis(nick.getLeftX()) * Drive.MAX_VELOCITY_METERS_PER_SECOND);
 
-    Function<Integer, Command> rotCommand =
-        (angle) ->
+    IntFunction<RotateAngleDriveCommand> rotCommand =
+        angle ->
             new RotateAngleDriveCommand(
                 drivebaseSubsystem, translationXSupplier, translationYSupplier, angle);
 

--- a/src/main/java/frc/robot/commands/HaltDriveCommandsCommand.java
+++ b/src/main/java/frc/robot/commands/HaltDriveCommandsCommand.java
@@ -1,0 +1,22 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import frc.robot.subsystems.DrivebaseSubsystem;
+
+// NOTE:  Consider using this command inline, rather than writing a subclass.  For more
+// information, see:
+// https://docs.wpilib.org/en/stable/docs/software/commandbased/convenience-features.html
+public class HaltDriveCommandsCommand extends InstantCommand {
+  public HaltDriveCommandsCommand(DrivebaseSubsystem drivebaseSubsystem) {
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(drivebaseSubsystem);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+}

--- a/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
+++ b/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
@@ -6,7 +6,9 @@ package frc.robot.commands;
 
 import edu.wpi.first.math.Pair;
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants.Drive;
 import frc.robot.subsystems.DrivebaseSubsystem;
+import frc.util.Util;
 import java.util.function.DoubleSupplier;
 
 public class RotateAngleDriveCommand extends CommandBase {
@@ -16,7 +18,6 @@ public class RotateAngleDriveCommand extends CommandBase {
   private final DoubleSupplier translationYSupplier;
 
   private final int targetAngle;
-  private boolean finished = false;
 
   /** Creates a new RotateAngleDriveCommand. */
   public RotateAngleDriveCommand(
@@ -40,12 +41,9 @@ public class RotateAngleDriveCommand extends CommandBase {
     double x = translationXSupplier.getAsDouble();
     double y = translationYSupplier.getAsDouble();
 
-    // You can use `new ChassisSpeeds(...)` for robot-oriented movement instead of field-oriented
-    // movement
-    finished =
-        drivebaseSubsystem.driveAngle(
-            new Pair<Double, Double>(x, y), targetAngle // the desired angle, gyro relative
-            );
+    drivebaseSubsystem.driveAngle(
+        new Pair<Double, Double>(x, y), targetAngle // the desired angle, gyro relative
+        );
   }
 
   // Called once the command ends or is interrupted.
@@ -55,6 +53,10 @@ public class RotateAngleDriveCommand extends CommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return finished;
+    return Util.epsilonEquals(
+        Util.relativeAngularDifference(
+            drivebaseSubsystem.getGyroscopeRotation().getDegrees(), targetAngle),
+        0,
+        Drive.ANGULAR_ERROR);
   }
 }

--- a/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
+++ b/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
@@ -17,7 +17,8 @@ public class RotateAngleDriveCommand extends CommandBase {
   private final DoubleSupplier translationXSupplier;
   private final DoubleSupplier translationYSupplier;
 
-  private int targetAngle;
+  private final int targetAngle;
+  private int cumTargetAngle;
   private boolean robotRelative = false;
 
   /** Creates a new RotateAngleDriveCommand. */
@@ -52,8 +53,10 @@ public class RotateAngleDriveCommand extends CommandBase {
 
   @Override
   public void initialize() {
+    System.out.println("init " + targetAngle);
+    cumTargetAngle = targetAngle;
     if (robotRelative) {
-      targetAngle += drivebaseSubsystem.getGyroscopeRotation().getDegrees();
+      cumTargetAngle += drivebaseSubsystem.getGyroscopeRotation().getDegrees();
     }
   }
 
@@ -64,7 +67,7 @@ public class RotateAngleDriveCommand extends CommandBase {
     double y = translationYSupplier.getAsDouble();
 
     drivebaseSubsystem.driveAngle(
-        new Pair<Double, Double>(x, y), targetAngle // the desired angle, gyro relative
+        new Pair<Double, Double>(x, y), cumTargetAngle // the desired angle, gyro relative
         );
   }
 
@@ -76,7 +79,8 @@ public class RotateAngleDriveCommand extends CommandBase {
   @Override
   public boolean isFinished() {
     return Util.epsilonZero(
-            Util.relativeAngularDifference(drivebaseSubsystem.getGyroscopeRotation(), targetAngle),
+            Util.relativeAngularDifference(
+                drivebaseSubsystem.getGyroscopeRotation(), cumTargetAngle),
             Drive.ANGULAR_ERROR)
         && Util.epsilonEquals(drivebaseSubsystem.getRotVelocity(), 0, 10);
   }

--- a/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
+++ b/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
@@ -1,0 +1,60 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.DrivebaseSubsystem;
+import frc.util.Util;
+import java.util.function.DoubleSupplier;
+
+public class RotateAngleDriveCommand extends CommandBase {
+  private final DrivebaseSubsystem drivebaseSubsystem;
+
+  private final DoubleSupplier translationXSupplier;
+  private final DoubleSupplier translationYSupplier;
+
+  private final int targetAngle;
+
+  /** Creates a new RotateAngleDriveCommand. */
+  public RotateAngleDriveCommand(
+      DrivebaseSubsystem drivebaseSubsystem,
+      DoubleSupplier translationXSupplier,
+      DoubleSupplier translationYSupplier,
+      int targetAngle) {
+
+    this.drivebaseSubsystem = drivebaseSubsystem;
+    this.translationXSupplier = translationXSupplier;
+    this.translationYSupplier = translationYSupplier;
+
+    this.targetAngle = targetAngle;
+
+    addRequirements(drivebaseSubsystem);
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    double x = translationXSupplier.getAsDouble();
+    double y = translationYSupplier.getAsDouble();
+
+    // You can use `new ChassisSpeeds(...)` for robot-oriented movement instead of field-oriented
+    // movement
+    drivebaseSubsystem.driveAngle(
+        ChassisSpeeds.fromFieldRelativeSpeeds(x, y, 0, drivebaseSubsystem.getGyroscopeRotation()),
+        targetAngle // the desired angle, gyro relative
+        );
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return Util.epsilonEquals(drivebaseSubsystem.getGyroscopeRotation().getDegrees(), targetAngle, .1);
+  }
+}

--- a/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
+++ b/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
@@ -18,7 +18,7 @@ public class RotateAngleDriveCommand extends CommandBase {
   private final DoubleSupplier translationYSupplier;
 
   private final int targetAngle;
-  private int cumTargetAngle;
+  private double cumTargetAngle;
   private boolean robotRelative = false;
 
   /** Creates a new RotateAngleDriveCommand. */
@@ -53,7 +53,6 @@ public class RotateAngleDriveCommand extends CommandBase {
 
   @Override
   public void initialize() {
-    System.out.println("init " + targetAngle);
     cumTargetAngle = targetAngle;
     if (robotRelative) {
       cumTargetAngle += drivebaseSubsystem.getGyroscopeRotation().getDegrees();

--- a/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
+++ b/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
@@ -7,7 +7,6 @@ package frc.robot.commands;
 import edu.wpi.first.math.Pair;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.DrivebaseSubsystem;
-import frc.util.Util;
 import java.util.function.DoubleSupplier;
 
 public class RotateAngleDriveCommand extends CommandBase {
@@ -17,6 +16,7 @@ public class RotateAngleDriveCommand extends CommandBase {
   private final DoubleSupplier translationYSupplier;
 
   private final int targetAngle;
+  private boolean finished = false;
 
   /** Creates a new RotateAngleDriveCommand. */
   public RotateAngleDriveCommand(
@@ -42,9 +42,10 @@ public class RotateAngleDriveCommand extends CommandBase {
 
     // You can use `new ChassisSpeeds(...)` for robot-oriented movement instead of field-oriented
     // movement
-    drivebaseSubsystem.driveAngle(
-        new Pair<Double, Double>(x, y), targetAngle // the desired angle, gyro relative
-        );
+    finished =
+        drivebaseSubsystem.driveAngle(
+            new Pair<Double, Double>(x, y), targetAngle // the desired angle, gyro relative
+            );
   }
 
   // Called once the command ends or is interrupted.
@@ -54,7 +55,6 @@ public class RotateAngleDriveCommand extends CommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return Util.epsilonEquals(
-        drivebaseSubsystem.getGyroscopeRotation().getDegrees(), targetAngle, .1);
+    return finished;
   }
 }

--- a/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
+++ b/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
@@ -17,7 +17,8 @@ public class RotateAngleDriveCommand extends CommandBase {
   private final DoubleSupplier translationXSupplier;
   private final DoubleSupplier translationYSupplier;
 
-  private final int targetAngle;
+  private int targetAngle;
+  private boolean robotRelative = false;
 
   /** Creates a new RotateAngleDriveCommand. */
   public RotateAngleDriveCommand(
@@ -33,6 +34,27 @@ public class RotateAngleDriveCommand extends CommandBase {
     this.targetAngle = targetAngle;
 
     addRequirements(drivebaseSubsystem);
+  }
+
+  public static RotateAngleDriveCommand fromRobotRelative(
+      DrivebaseSubsystem drivebaseSubsystem,
+      DoubleSupplier translationXSupplier,
+      DoubleSupplier translationYSupplier,
+      int targetAngle) {
+
+    var command =
+        new RotateAngleDriveCommand(
+            drivebaseSubsystem, translationXSupplier, translationYSupplier, targetAngle);
+
+    command.robotRelative = true;
+    return command;
+  }
+
+  @Override
+  public void initialize() {
+    if (robotRelative) {
+      targetAngle += drivebaseSubsystem.getGyroscopeRotation().getDegrees();
+    }
   }
 
   // Called every time the scheduler runs while the command is scheduled.

--- a/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
+++ b/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
@@ -5,7 +5,6 @@
 package frc.robot.commands;
 
 import edu.wpi.first.math.Pair;
-import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.DrivebaseSubsystem;
 import frc.util.Util;
@@ -44,8 +43,7 @@ public class RotateAngleDriveCommand extends CommandBase {
     // You can use `new ChassisSpeeds(...)` for robot-oriented movement instead of field-oriented
     // movement
     drivebaseSubsystem.driveAngle(
-        new Pair<Double, Double>(x, y),
-        targetAngle // the desired angle, gyro relative
+        new Pair<Double, Double>(x, y), targetAngle // the desired angle, gyro relative
         );
   }
 

--- a/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
+++ b/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
@@ -55,6 +55,7 @@ public class RotateAngleDriveCommand extends CommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return Util.epsilonEquals(drivebaseSubsystem.getGyroscopeRotation().getDegrees(), targetAngle, .1);
+    return Util.epsilonEquals(
+        drivebaseSubsystem.getGyroscopeRotation().getDegrees(), targetAngle, .1);
   }
 }

--- a/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
+++ b/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
@@ -53,10 +53,8 @@ public class RotateAngleDriveCommand extends CommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return Util.epsilonEquals(
-        Util.relativeAngularDifference(
-            drivebaseSubsystem.getGyroscopeRotation().getDegrees(), targetAngle),
-        0,
+    return Util.epsilonZero(
+        Util.relativeAngularDifference(drivebaseSubsystem.getGyroscopeRotation(), targetAngle),
         Drive.ANGULAR_ERROR);
   }
 }

--- a/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
+++ b/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
@@ -76,7 +76,8 @@ public class RotateAngleDriveCommand extends CommandBase {
   @Override
   public boolean isFinished() {
     return Util.epsilonZero(
-        Util.relativeAngularDifference(drivebaseSubsystem.getGyroscopeRotation(), targetAngle),
-        Drive.ANGULAR_ERROR);
+            Util.relativeAngularDifference(drivebaseSubsystem.getGyroscopeRotation(), targetAngle),
+            Drive.ANGULAR_ERROR)
+        && Util.epsilonEquals(drivebaseSubsystem.getRotVelocity(), 0, 10);
   }
 }

--- a/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
+++ b/src/main/java/frc/robot/commands/RotateAngleDriveCommand.java
@@ -4,6 +4,7 @@
 
 package frc.robot.commands;
 
+import edu.wpi.first.math.Pair;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.subsystems.DrivebaseSubsystem;
@@ -43,7 +44,7 @@ public class RotateAngleDriveCommand extends CommandBase {
     // You can use `new ChassisSpeeds(...)` for robot-oriented movement instead of field-oriented
     // movement
     drivebaseSubsystem.driveAngle(
-        ChassisSpeeds.fromFieldRelativeSpeeds(x, y, 0, drivebaseSubsystem.getGyroscopeRotation()),
+        new Pair<Double, Double>(x, y),
         targetAngle // the desired angle, gyro relative
         );
   }

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -50,7 +50,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
   private final PIDController rotController;
 
   private ChassisSpeeds chassisSpeeds = new ChassisSpeeds(); // defaults to zeros
-  private int targetAngle = 0; // default target angle to zero
+  private double targetAngle = 0; // default target angle to zero
   private Pair<Double, Double> xyInput = new Pair<>(0d, 0d); // the x and y for using target angles
 
   /**
@@ -185,7 +185,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
     mode = Modes.DRIVE;
   }
 
-  public void driveAngle(Pair<Double, Double> xyInput, int targetAngle) {
+  public void driveAngle(Pair<Double, Double> xyInput, double targetAngle) {
     this.xyInput = xyInput;
     this.targetAngle = targetAngle;
     if (mode != Modes.DRIVE_ANGLE) rotController.reset();

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -22,7 +22,6 @@ import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInLayouts;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.util.Util;
 
@@ -131,7 +130,8 @@ public class DrivebaseSubsystem extends SubsystemBase {
     rotController = new PIDController(.0175, 0, 0.0015);
     rotController.setSetpoint(0);
     rotController.setTolerance(ANGULAR_ERROR); // degrees error
-    Shuffleboard.getTab("Drivebase").add(rotController);
+    // tune pid with:
+    // Shuffleboard.getTab("Drivebase").add(rotController);
   }
 
   /** Sets the gyro angle to zero, resetting the forward direction */
@@ -148,9 +148,6 @@ public class DrivebaseSubsystem extends SubsystemBase {
     double angle = 360d - navx.getYaw();
 
     angle %= 360;
-    SmartDashboard.putNumber("mod angle", angle);
-    SmartDashboard.putNumber(
-        "stale angular diff", Util.relativeAngularDifference(angle, targetAngle));
 
     // We have to invert the angle of the NavX so that rotating the robot counter-clockwise makes
     // the angle increase.
@@ -167,7 +164,6 @@ public class DrivebaseSubsystem extends SubsystemBase {
     rotVelocity = (angle - lastAngle) / (time - lastTime);
     lastTime = time;
     lastAngle = angle;
-    SmartDashboard.putNumber("rot vel", rotVelocity);
   }
 
   public double getRotVelocity() {
@@ -232,12 +228,6 @@ public class DrivebaseSubsystem extends SubsystemBase {
 
     // this value makes our unit-less [-1, 1] into [-max angular, max angular]
     double omegaRadiansPerSecond = rotationValue * MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND;
-
-    SmartDashboard.putNumber("target angle", targetAngle);
-    SmartDashboard.putNumber("robot angle", getGyroscopeRotation().getDegrees());
-    SmartDashboard.putNumber("angular difference", angularDifference);
-    SmartDashboard.putNumber("rotation value", rotationValue);
-    SmartDashboard.putNumber("omega", omegaRadiansPerSecond);
 
     // initialize chassis speeds but add our desired angle
     chassisSpeeds =

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -129,6 +129,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
 
     rotController = new PIDController(.02, 0, 0.001);
     rotController.setSetpoint(0);
+    rotController.setTolerance(1); // degrees error
   }
 
   /** Sets the gyro angle to zero, resetting the forward direction */

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -123,6 +123,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
         new SwerveModule[] {frontRightModule, frontLeftModule, backLeftModule, backRightModule};
 
     rotController = new PIDController(0.1, 0, 0);
+    rotController.enableContinuousInput(-1, 1);
   }
 
   /** Sets the gyro angle to zero, resetting the forward direction */
@@ -190,8 +191,9 @@ public class DrivebaseSubsystem extends SubsystemBase {
 
   // called in drive to angle mode
   private void driveAnglePeriodic() {
+    double rotationValue = rotController.calculate(getGyroscopeRotation().getDegrees(), targetAngle);
     // reinitialize chassis speeds but add our desired angle
-    double omegaRadiansPerSecond = 0 * MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND;
+    double omegaRadiansPerSecond = rotationValue * MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND;
     chassisSpeeds =
         new ChassisSpeeds(
             chassisSpeeds.vxMetersPerSecond,

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -127,7 +127,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
     swerveModules = // modules are always initialized and passed in this order
         new SwerveModule[] {frontRightModule, frontLeftModule, backLeftModule, backRightModule};
 
-    rotController = new PIDController(3, 0, 0);
+    rotController = new PIDController(.02, 0, 0.001);
     rotController.setSetpoint(0);
   }
 
@@ -161,6 +161,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
   public void driveAngle(Pair<Double, Double> xyInput, int targetAngle) {
     this.xyInput = xyInput;
     this.targetAngle = targetAngle;
+    if (mode != Modes.DRIVE_ANGLE) rotController.reset();
     mode = Modes.DRIVE_ANGLE;
   }
 

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -17,7 +17,6 @@ import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
-import edu.wpi.first.util.sendable.Sendable;
 import edu.wpi.first.wpilibj.SPI;
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInLayouts;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
@@ -195,9 +194,15 @@ public class DrivebaseSubsystem extends SubsystemBase {
 
   // called in drive to angle mode
   private void driveAnglePeriodic() {
-    double rotationValue = rotController.calculate(getGyroscopeRotation().getCos(), Rotation2d.fromDegrees(targetAngle).getCos());
+    double rotationValue =
+        rotController.calculate(
+            getGyroscopeRotation().getCos(), Rotation2d.fromDegrees(targetAngle).getCos());
 
-    rotationValue = MathUtil.clamp(rotationValue, -1, 1); // we are treating this like a joystick, so -1 and 1 are its lower and upper bound
+    rotationValue =
+        MathUtil.clamp(
+            rotationValue,
+            -1,
+            1); // we are treating this like a joystick, so -1 and 1 are its lower and upper bound
 
     // this value makes our unit-less [-1, 1] into [-max angular, max angular]
     double omegaRadiansPerSecond = rotationValue * MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND;
@@ -206,14 +211,11 @@ public class DrivebaseSubsystem extends SubsystemBase {
     SmartDashboard.putNumber("robot angle", getGyroscopeRotation().getCos());
     SmartDashboard.putNumber("rotation value", rotationValue);
     SmartDashboard.putNumber("omega", omegaRadiansPerSecond);
-    
+
     // initialize chassis speeds but add our desired angle
-    chassisSpeeds = ChassisSpeeds.fromFieldRelativeSpeeds(
-          xyInput.getFirst(),
-          xyInput.getSecond(),
-          omegaRadiansPerSecond,
-          getGyroscopeRotation()
-        );
+    chassisSpeeds =
+        ChassisSpeeds.fromFieldRelativeSpeeds(
+            xyInput.getFirst(), xyInput.getSecond(), omegaRadiansPerSecond, getGyroscopeRotation());
     // use the existing drive periodic logic to assign to motors ect
     drivePeriodic();
   }

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -147,6 +147,8 @@ public class DrivebaseSubsystem extends SubsystemBase {
 
     angle %= 360;
     SmartDashboard.putNumber("mod angle", angle);
+    SmartDashboard.putNumber(
+        "stale angular diff", Util.relativeAngularDifference(angle, targetAngle));
 
     // We have to invert the angle of the NavX so that rotating the robot counter-clockwise makes
     // the angle increase.

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -18,6 +18,7 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.SPI;
+import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.shuffleboard.BuiltInLayouts;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
@@ -155,6 +156,23 @@ public class DrivebaseSubsystem extends SubsystemBase {
     return Rotation2d.fromDegrees(angle);
   }
 
+  private double lastAngle = 0;
+  private double lastTime = 0;
+  private double rotVelocity = 0;
+
+  private void updateRotVelocity() {
+    double time = Timer.getFPGATimestamp();
+    double angle = getGyroscopeRotation().getDegrees();
+    rotVelocity = (angle - lastAngle) / (time - lastTime);
+    lastTime = time;
+    lastAngle = angle;
+    SmartDashboard.putNumber("rot vel", rotVelocity);
+  }
+
+  public double getRotVelocity() {
+    return rotVelocity;
+  }
+
   /**
    * Tells the subsystem to drive, and puts the state machine in drive mode
    *
@@ -242,6 +260,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
 
   @Override
   public void periodic() {
+    updateRotVelocity();
     switch (mode) {
       case DRIVE:
         drivePeriodic();

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -129,7 +129,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
 
     rotController = new PIDController(.02, 0.0001, 0.001);
     rotController.setSetpoint(0);
-    rotController.setTolerance(1); // degrees error
+    rotController.setTolerance(ANGULAR_ERROR); // degrees error
   }
 
   /** Sets the gyro angle to zero, resetting the forward direction */
@@ -159,12 +159,11 @@ public class DrivebaseSubsystem extends SubsystemBase {
     mode = Modes.DRIVE;
   }
 
-  public boolean driveAngle(Pair<Double, Double> xyInput, int targetAngle) {
+  public void driveAngle(Pair<Double, Double> xyInput, int targetAngle) {
     this.xyInput = xyInput;
     this.targetAngle = targetAngle;
     if (mode != Modes.DRIVE_ANGLE) rotController.reset();
     mode = Modes.DRIVE_ANGLE;
-    return rotController.atSetpoint();
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -191,7 +191,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
   // called in drive to angle mode
   private void driveAnglePeriodic() {
     // reinitialize chassis speeds but add our desired angle
-    int omegaRadiansPerSecond = 0;
+    double omegaRadiansPerSecond = 0 * MAX_ANGULAR_VELOCITY_RADIANS_PER_SECOND;
     chassisSpeeds =
         new ChassisSpeeds(
             chassisSpeeds.vxMetersPerSecond,

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -198,8 +198,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
 
   // called in drive to angle mode
   private void driveAnglePeriodic() {
-    double angularDifference =
-        Util.relativeAngularDifference(getGyroscopeRotation().getDegrees(), targetAngle);
+    double angularDifference = Util.relativeAngularDifference(getGyroscopeRotation(), targetAngle);
     double rotationValue = rotController.calculate(angularDifference);
 
     // we are treating this like a joystick, so -1 and 1 are its lower and upper bound

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -143,9 +143,14 @@ public class DrivebaseSubsystem extends SubsystemBase {
       return Rotation2d.fromDegrees(navx.getFusedHeading());
     }
 
+    double angle = 360d - navx.getYaw();
+
+    angle %= 360;
+    SmartDashboard.putNumber("mod angle", angle);
+
     // We have to invert the angle of the NavX so that rotating the robot counter-clockwise makes
     // the angle increase.
-    return Rotation2d.fromDegrees(360.0 - navx.getYaw());
+    return Rotation2d.fromDegrees(angle);
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -127,7 +127,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
     swerveModules = // modules are always initialized and passed in this order
         new SwerveModule[] {frontRightModule, frontLeftModule, backLeftModule, backRightModule};
 
-    rotController = new PIDController(.02, 0, 0.001);
+    rotController = new PIDController(.02, 0.0001, 0.001);
     rotController.setSetpoint(0);
     rotController.setTolerance(1); // degrees error
   }
@@ -159,11 +159,12 @@ public class DrivebaseSubsystem extends SubsystemBase {
     mode = Modes.DRIVE;
   }
 
-  public void driveAngle(Pair<Double, Double> xyInput, int targetAngle) {
+  public boolean driveAngle(Pair<Double, Double> xyInput, int targetAngle) {
     this.xyInput = xyInput;
     this.targetAngle = targetAngle;
     if (mode != Modes.DRIVE_ANGLE) rotController.reset();
     mode = Modes.DRIVE_ANGLE;
+    return rotController.atSetpoint();
   }
 
   /**

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -128,7 +128,7 @@ public class DrivebaseSubsystem extends SubsystemBase {
     swerveModules = // modules are always initialized and passed in this order
         new SwerveModule[] {frontRightModule, frontLeftModule, backLeftModule, backRightModule};
 
-    rotController = new PIDController(.07, 0, 0);
+    rotController = new PIDController(.0175, 0, 0.0015);
     rotController.setSetpoint(0);
     rotController.setTolerance(ANGULAR_ERROR); // degrees error
     Shuffleboard.getTab("Drivebase").add(rotController);

--- a/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivebaseSubsystem.java
@@ -128,9 +128,10 @@ public class DrivebaseSubsystem extends SubsystemBase {
     swerveModules = // modules are always initialized and passed in this order
         new SwerveModule[] {frontRightModule, frontLeftModule, backLeftModule, backRightModule};
 
-    rotController = new PIDController(.02, 0.0001, 0.001);
+    rotController = new PIDController(.07, 0, 0);
     rotController.setSetpoint(0);
     rotController.setTolerance(ANGULAR_ERROR); // degrees error
+    Shuffleboard.getTab("Drivebase").add(rotController);
   }
 
   /** Sets the gyro angle to zero, resetting the forward direction */

--- a/src/main/java/frc/util/ControllerUtil.java
+++ b/src/main/java/frc/util/ControllerUtil.java
@@ -1,0 +1,19 @@
+package frc.util;
+
+import java.util.function.BooleanSupplier;
+
+public class ControllerUtil {
+  private ControllerUtil() {}
+  /**
+   * Compares a layer button with a layer state, and if they match returns the layered button
+   *
+   * @param layer the boolean supplier that is the layer switch
+   * @param layerState the state of the layer switch that is valid
+   * @param button the button inside the layer
+   * @return true if the layer is enabled and the button is pressed
+   */
+  public static BooleanSupplier cumBooleanSupplier(
+      BooleanSupplier layer, boolean layerState, BooleanSupplier button) {
+    return () -> layer.getAsBoolean() == layerState && button.getAsBoolean();
+  }
+}

--- a/src/main/java/frc/util/ControllerUtil.java
+++ b/src/main/java/frc/util/ControllerUtil.java
@@ -3,6 +3,27 @@ package frc.util;
 import java.util.function.BooleanSupplier;
 
 public class ControllerUtil {
+  /**
+   * Scales radial deadband
+   *
+   * <p>The deadband value is set to be the new zero
+   *
+   * @param value the raw value
+   * @param deadband the deadband range
+   * @return the value with radial deadband applied
+   */
+  public static double deadband(double value, double deadband) {
+    if (Math.abs(value) > deadband) {
+      if (value > 0.0) {
+        return (value - deadband) / (1.0 - deadband);
+      } else {
+        return (value + deadband) / (1.0 - deadband);
+      }
+    } else {
+      return 0.0;
+    }
+  }
+
   private ControllerUtil() {}
   /**
    * Compares a layer button with a layer state, and if they match returns the layered button

--- a/src/main/java/frc/util/Layer.java
+++ b/src/main/java/frc/util/Layer.java
@@ -4,30 +4,79 @@ import edu.wpi.first.wpilibj2.command.button.Button;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import java.util.function.BooleanSupplier;
 
+/**
+ * An object to use a {@link Button} or {@link Trigger} as a layerSwitch to form two layers of
+ * virtual buttons, with the switch on or off
+ */
 public class Layer {
+  /**
+   * the trigger that is used for on and off states for the layer such that the states correspond to
+   * the state of the trigger
+   */
+  private final Trigger layerSwitch;
 
-  private Trigger layerSwitch;
-
+  /**
+   * Constructs a new Layer based off of an arbitrary boolean supplier.
+   *
+   * @param layerSwitch BooleanSupplier representing the layer root.
+   */
   public Layer(BooleanSupplier layerSwitch) {
     this.layerSwitch = new Button(layerSwitch);
   }
 
+  /**
+   * Constructs a new Layer based off of a {@link Trigger}.
+   *
+   * @param layerSwitch WPILib Trigger representing the layer root.
+   */
   public Layer(Trigger layerSwitch) {
     this.layerSwitch = layerSwitch;
   }
 
+  /**
+   * Combines a {@link Trigger} with the layer root provided that the layer switch is activated.
+   *
+   * @param button the {@link Trigger} that is used in tandem with the layer for the virtual button
+   * @return virtual {@link Button} that is pressed when the layer switch and the provided button is
+   *     pressed
+   */
   public Button on(Trigger button) {
     return new Button(layerSwitch.and(button));
   }
 
-  public Button off(Trigger button) {
-    return new Button(layerSwitch.negate().and(button));
-  }
-
+  /**
+   * Combines a {@link BooleanSupplier} with the layer root provided that the layer switch is
+   * activated.
+   *
+   * @param button the {@link BooleanSupplier} that is used in tandem with the layer for the virtual
+   *     button
+   * @return virtual {@link Button} that is pressed when the layer switch and the provided button is
+   *     pressed
+   */
   public Button on(BooleanSupplier boolSupplier) {
     return on(new Button(boolSupplier));
   }
 
+  /**
+   * Combines a {@link Trigger} with the layer root provided that the layer switch is not activated.
+   *
+   * @param button the {@link Trigger} that is used in tandem with the layer for the virtual button
+   * @return virtual {@link Button} that is pressed when the layer switch is not pressed, but the
+   *     provided button is pressed
+   */
+  public Button off(Trigger button) {
+    return new Button(layerSwitch.negate().and(button));
+  }
+
+  /**
+   * Combines a {@link BooleanSupplier} with the layer root provided that the layer switch is not
+   * activated.
+   *
+   * @param button the {@link BooleanSupplier} that is used in tandem with the layer for the virtual
+   *     button
+   * @return virtual {@link Button} that is pressed when the layer switch is not pressed, but the
+   *     provided button is pressed
+   */
   public Button off(BooleanSupplier boolSupplier) {
     return off(new Button(boolSupplier));
   }

--- a/src/main/java/frc/util/Layer.java
+++ b/src/main/java/frc/util/Layer.java
@@ -16,11 +16,19 @@ public class Layer {
     this.layerSwitch = layerSwitch;
   }
 
-  public Trigger on(BooleanSupplier boolSupplier) {
-    return layerSwitch.and(new Button(boolSupplier));
+  public Button on(Trigger button) {
+    return new Button(layerSwitch.and(button));
   }
 
-  public Trigger on(Trigger button) {
-    return layerSwitch.and(button);
+  public Button off(Trigger button) {
+    return new Button(layerSwitch.negate().and(button));
+  }
+
+  public Button on(BooleanSupplier boolSupplier) {
+    return on(new Button(boolSupplier));
+  }
+
+  public Button off(BooleanSupplier boolSupplier) {
+    return off(new Button(boolSupplier));
   }
 }

--- a/src/main/java/frc/util/Layer.java
+++ b/src/main/java/frc/util/Layer.java
@@ -1,0 +1,26 @@
+package frc.util;
+
+import edu.wpi.first.wpilibj2.command.button.Button;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
+import java.util.function.BooleanSupplier;
+
+public class Layer {
+
+  private Trigger layerSwitch;
+
+  public Layer(BooleanSupplier layerSwitch) {
+    this.layerSwitch = new Button(layerSwitch);
+  }
+
+  public Layer(Trigger layerSwitch) {
+    this.layerSwitch = layerSwitch;
+  }
+
+  public Trigger on(BooleanSupplier boolSupplier) {
+    return layerSwitch.and(new Button(boolSupplier));
+  }
+
+  public Trigger on(Trigger button) {
+    return layerSwitch.and(button);
+  }
+}

--- a/src/main/java/frc/util/Util.java
+++ b/src/main/java/frc/util/Util.java
@@ -1,6 +1,7 @@
 package frc.util;
 
 import edu.wpi.first.math.geometry.Rotation2d;
+import java.util.function.BooleanSupplier;
 
 public class Util {
   private Util() {}
@@ -51,5 +52,18 @@ public class Util {
 
   public static double relativeAngularDifference(Rotation2d currentAngle, double newAngle) {
     return relativeAngularDifference(currentAngle.getDegrees(), newAngle);
+  }
+
+  /**
+   * Compares a layer button with a layer state, and if they match returns the layered button
+   *
+   * @param layer the boolean supplier that is the layer switch
+   * @param layerState the state of the layer switch that is valid
+   * @param button the button inside the layer
+   * @return true if the layer is enabled and the button is pressed
+   */
+  public static BooleanSupplier cumBooleanSupplier(
+      BooleanSupplier layer, boolean layerState, BooleanSupplier button) {
+    return () -> layer.getAsBoolean() == layerState && button.getAsBoolean();
   }
 }

--- a/src/main/java/frc/util/Util.java
+++ b/src/main/java/frc/util/Util.java
@@ -41,4 +41,40 @@ public class Util {
       return 0.0;
     }
   }
+
+  /**
+   * This function makes a target angle relative to a new angle, for use in swerve code and other
+   * situations where relative angles are easier to work with
+   *
+   * <p>lifted from:
+   * https://github.com/frc1678/2910-clone/blob/b3c9e66cf49067b651ac658bd0c4406443e0ea86/src/main/java/com/team1678/lib/util/CTREModuleState.java#L32-L56
+   *
+   * @param scopeReference Current Angle, to make things relative
+   * @param newAngle Target Angle
+   * @return Closest angle within scope
+   */
+  private static double placeInAppropriate0To360Scope(double scopeReference, double newAngle) {
+    double lowerBound;
+    double upperBound;
+    double lowerOffset = scopeReference % 360;
+    if (lowerOffset >= 0) {
+      lowerBound = scopeReference - lowerOffset;
+      upperBound = scopeReference + (360 - lowerOffset);
+    } else {
+      upperBound = scopeReference - lowerOffset;
+      lowerBound = scopeReference - (360 + lowerOffset);
+    }
+    while (newAngle < lowerBound) {
+      newAngle += 360;
+    }
+    while (newAngle > upperBound) {
+      newAngle -= 360;
+    }
+    if (newAngle - scopeReference > 180) {
+      newAngle -= 360;
+    } else if (newAngle - scopeReference < -180) {
+      newAngle += 360;
+    }
+    return newAngle;
+  }
 }

--- a/src/main/java/frc/util/Util.java
+++ b/src/main/java/frc/util/Util.java
@@ -1,24 +1,16 @@
 package frc.util;
 
+import edu.wpi.first.math.geometry.Rotation2d;
+
 public class Util {
   private Util() {}
-
-  private static double kEpsilon = 1e-5;
 
   public static boolean epsilonEquals(double a, double b, double epsilon) {
     return (a - epsilon <= b) && (a + epsilon >= b);
   }
 
-  public static boolean epsilonEquals(int a, int b, int epsilon) {
-    return (a - epsilon <= b) && (a + epsilon >= b);
-  }
-
-  public static boolean epsilonEquals(double a, double b) {
-    return epsilonEquals(a, b, kEpsilon);
-  }
-
-  public static boolean epsilonEquals(int a, int b) {
-    return epsilonEquals(a, b, kEpsilon);
+  public static boolean epsilonZero(double a, double epsilon) {
+    return epsilonEquals(a, 0, epsilon);
   }
 
   /**
@@ -55,5 +47,9 @@ public class Util {
     newAngle %= 360;
     double negDifference = currentAngle - newAngle;
     return negDifference < -180 ? 360 + negDifference : negDifference;
+  }
+
+  public static double relativeAngularDifference(Rotation2d currentAngle, double newAngle) {
+    return relativeAngularDifference(currentAngle.getDegrees(), newAngle);
   }
 }

--- a/src/main/java/frc/util/Util.java
+++ b/src/main/java/frc/util/Util.java
@@ -43,13 +43,17 @@ public class Util {
   }
 
   /**
-   * This function finds the degree difference between angles, the shortest path. useful for pid control of drivebase rotation
+   * This function finds the degree difference between angles, the shortest path. useful for pid
+   * control of drivebase rotation
    *
    * @param currentAngle Current Angle Degrees
-   * @param newAngle Target Angle Degrees 
+   * @param newAngle Target Angle Degrees
    * @return Shortest angular difference in degrees
    */
   public static double relativeAngularDifference(double currentAngle, double newAngle) {
-    return currentAngle - newAngle;
+    currentAngle %= 360;
+    newAngle %= 360;
+    double negDifference = currentAngle - newAngle;
+    return negDifference < -180 ? 360 + negDifference : negDifference;
   }
 }

--- a/src/main/java/frc/util/Util.java
+++ b/src/main/java/frc/util/Util.java
@@ -1,7 +1,6 @@
 package frc.util;
 
 import edu.wpi.first.math.geometry.Rotation2d;
-import java.util.function.BooleanSupplier;
 
 public class Util {
   private Util() {}
@@ -52,18 +51,5 @@ public class Util {
 
   public static double relativeAngularDifference(Rotation2d currentAngle, double newAngle) {
     return relativeAngularDifference(currentAngle.getDegrees(), newAngle);
-  }
-
-  /**
-   * Compares a layer button with a layer state, and if they match returns the layered button
-   *
-   * @param layer the boolean supplier that is the layer switch
-   * @param layerState the state of the layer switch that is valid
-   * @param button the button inside the layer
-   * @return true if the layer is enabled and the button is pressed
-   */
-  public static BooleanSupplier cumBooleanSupplier(
-      BooleanSupplier layer, boolean layerState, BooleanSupplier button) {
-    return () -> layer.getAsBoolean() == layerState && button.getAsBoolean();
   }
 }

--- a/src/main/java/frc/util/Util.java
+++ b/src/main/java/frc/util/Util.java
@@ -43,38 +43,13 @@ public class Util {
   }
 
   /**
-   * This function makes a target angle relative to a new angle, for use in swerve code and other
-   * situations where relative angles are easier to work with
+   * This function finds the degree difference between angles, the shortest path. useful for pid control of drivebase rotation
    *
-   * <p>lifted from:
-   * https://github.com/frc1678/2910-clone/blob/b3c9e66cf49067b651ac658bd0c4406443e0ea86/src/main/java/com/team1678/lib/util/CTREModuleState.java#L32-L56
-   *
-   * @param scopeReference Current Angle, to make things relative
-   * @param newAngle Target Angle
-   * @return Closest angle within scope
+   * @param currentAngle Current Angle Degrees
+   * @param newAngle Target Angle Degrees 
+   * @return Shortest angular difference in degrees
    */
-  private static double placeInAppropriate0To360Scope(double scopeReference, double newAngle) {
-    double lowerBound;
-    double upperBound;
-    double lowerOffset = scopeReference % 360;
-    if (lowerOffset >= 0) {
-      lowerBound = scopeReference - lowerOffset;
-      upperBound = scopeReference + (360 - lowerOffset);
-    } else {
-      upperBound = scopeReference - lowerOffset;
-      lowerBound = scopeReference - (360 + lowerOffset);
-    }
-    while (newAngle < lowerBound) {
-      newAngle += 360;
-    }
-    while (newAngle > upperBound) {
-      newAngle -= 360;
-    }
-    if (newAngle - scopeReference > 180) {
-      newAngle -= 360;
-    } else if (newAngle - scopeReference < -180) {
-      newAngle += 360;
-    }
-    return newAngle;
+  public static double relativeAngularDifference(double currentAngle, double newAngle) {
+    return currentAngle - newAngle;
   }
 }

--- a/src/main/java/frc/util/Util.java
+++ b/src/main/java/frc/util/Util.java
@@ -14,27 +14,6 @@ public class Util {
   }
 
   /**
-   * Scales radial deadband
-   *
-   * <p>The deadband value is set to be the new zero
-   *
-   * @param value the raw value
-   * @param deadband the deadband range
-   * @return the value with radial deadband applied
-   */
-  public static double deadband(double value, double deadband) {
-    if (Math.abs(value) > deadband) {
-      if (value > 0.0) {
-        return (value - deadband) / (1.0 - deadband);
-      } else {
-        return (value + deadband) / (1.0 - deadband);
-      }
-    } else {
-      return 0.0;
-    }
-  }
-
-  /**
    * This function finds the degree difference between angles, the shortest path. useful for pid
    * control of drivebase rotation
    *

--- a/src/main/java/frc/util/Util.java
+++ b/src/main/java/frc/util/Util.java
@@ -28,8 +28,8 @@ public class Util {
     double difference2 = Math.abs(360 - difference1);
     double difference = difference1 < difference2 ? difference1 : difference2;
 
-    if ((currentAngle + difference) % 360 == newAngle) return difference;
-    return difference * -1;
+    if ((currentAngle + difference) % 360 == newAngle) return difference * -1;
+    return difference;
   }
 
   public static double relativeAngularDifference(Rotation2d currentAngle, double newAngle) {

--- a/src/main/java/frc/util/Util.java
+++ b/src/main/java/frc/util/Util.java
@@ -24,8 +24,12 @@ public class Util {
   public static double relativeAngularDifference(double currentAngle, double newAngle) {
     currentAngle %= 360;
     newAngle %= 360;
-    double negDifference = currentAngle - newAngle;
-    return negDifference < -180 ? 360 + negDifference : negDifference;
+    double difference1 = Math.abs(currentAngle - newAngle);
+    double difference2 = Math.abs(360 - difference1);
+    double difference = difference1 < difference2 ? difference1 : difference2;
+
+    if ((currentAngle + difference) % 360 == newAngle) return difference;
+    return difference * -1;
   }
 
   public static double relativeAngularDifference(Rotation2d currentAngle, double newAngle) {

--- a/src/test/java/frc/util/ControllerUtilTests.java
+++ b/src/test/java/frc/util/ControllerUtilTests.java
@@ -1,0 +1,19 @@
+package frc.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import frc.UtilTest;
+
+public class ControllerUtilTests {
+  @UtilTest
+  public void deadbandScalesCorrectly() {
+    assertEquals(1.0, ControllerUtil.deadband(1.0, .3), "deadband should still max out");
+    assertEquals(0.0, ControllerUtil.deadband(.1, .2), "value should be zero when inside deadband");
+    assertEquals(
+        0.2,
+        ControllerUtil.deadband(.6, .5),
+        1e-5 // epsilon for equality assertion
+        ,
+        "value should scale such that range from deadband to 1 is mapped to 0 to 1");
+  }
+}

--- a/src/test/java/frc/util/LayerTests.java
+++ b/src/test/java/frc/util/LayerTests.java
@@ -1,0 +1,55 @@
+package frc.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.wpi.first.wpilibj2.command.button.Button;
+import frc.UtilTest;
+import org.junit.jupiter.api.BeforeEach;
+
+public class LayerTests {
+  private boolean switchVal = false;
+  private Button layerSwitch = new Button(() -> switchVal);
+
+  private boolean buttonAVal = false;
+  private Button buttonA = new Button(() -> buttonAVal);
+
+  private boolean buttonBVal = false;
+  private Button buttonB = new Button(() -> buttonBVal);
+
+  private Layer layer = new Layer(layerSwitch);
+
+  private Button buttonALayerOff = layer.off(buttonA);
+  private Button buttonALayerOn = layer.on(buttonA);
+
+  private Button buttonBLayerOff = layer.off(buttonB);
+  private Button buttonBLayerOn = layer.on(buttonB);
+
+  @BeforeEach
+  public void setup() {
+    switchVal = false;
+    buttonAVal = false;
+    buttonBVal = false;
+  }
+
+  @UtilTest
+  public void buttonTrueWhenLayerOffAndButtonOn() {
+    buttonAVal = true;
+    assertTrue(buttonALayerOff);
+  }
+
+  @UtilTest
+  public void buttonFalseWhenFalseRegardlessOfLayer() {
+    assertFalse(buttonALayerOff);
+    assertFalse(buttonALayerOn);
+  }
+
+  @UtilTest
+  public void buttonTrueConditionalOnLayer() {
+    buttonBVal = true;
+    assertFalse(buttonALayerOff);
+    assertFalse(buttonBLayerOn);
+    switchVal = true;
+    assertTrue(buttonBLayerOn);
+  }
+}

--- a/src/test/java/frc/util/UtilTests.java
+++ b/src/test/java/frc/util/UtilTests.java
@@ -8,18 +8,6 @@ import frc.UtilTest;
 
 public class UtilTests {
   @UtilTest
-  public void deadbandScalesCorrectly() {
-    assertEquals(1.0, Util.deadband(1.0, .3), "deadband should still max out");
-    assertEquals(0.0, Util.deadband(.1, .2), "value should be zero when inside deadband");
-    assertEquals(
-        0.2,
-        Util.deadband(.6, .5),
-        1e-5 // epsilon for equality assertion
-        ,
-        "value should scale such that range from deadband to 1 is mapped to 0 to 1");
-  }
-
-  @UtilTest
   public void epsilonReturnsTrueWhenEqual() {
     assertTrue(Util.epsilonEquals(2, 2.1, .2));
     assertTrue(Util.epsilonEquals(2, 2.1, .1));

--- a/src/test/java/frc/util/UtilTests.java
+++ b/src/test/java/frc/util/UtilTests.java
@@ -32,7 +32,16 @@ public class UtilTests {
   }
 
   @UtilTest
-  public void relativeAngularDifferenceWorks() {
+  public void relativeAngularDifferenceZerosOnEquivalent() {
     assertEquals(0, Util.relativeAngularDifference(100, 100));
+    assertEquals(0, Util.relativeAngularDifference(0, 360 * 2));
+  }
+
+  @UtilTest
+  public void relativeAngularDifferenceTakesShortestPath() {
+    assertEquals(-100, Util.relativeAngularDifference(360, 360 + 100));
+    assertEquals(60, Util.relativeAngularDifference(360, 360 + 300));
+    assertEquals(179, Util.relativeAngularDifference(0, 181));
+    assertEquals(-170, Util.relativeAngularDifference(0, 170));
   }
 }

--- a/src/test/java/frc/util/UtilTests.java
+++ b/src/test/java/frc/util/UtilTests.java
@@ -27,12 +27,12 @@ public class UtilTests {
 
   @UtilTest
   public void relativeAngularDifferenceTakesShortestPath() {
-    assertEquals(100, Util.relativeAngularDifference(0, 100));
-    assertEquals(100, Util.relativeAngularDifference(360, 360 + 100));
-    assertEquals(-60, Util.relativeAngularDifference(360, 360 + 300));
-    assertEquals(-179, Util.relativeAngularDifference(0, 181));
-    assertEquals(170, Util.relativeAngularDifference(0, 170));
-    assertEquals(90, Util.relativeAngularDifference(270, 360));
-    assertEquals(90, Util.relativeAngularDifference(270, 0));
+    assertEquals(-100, Util.relativeAngularDifference(0, 100));
+    assertEquals(-100, Util.relativeAngularDifference(360, 360 + 100));
+    assertEquals(60, Util.relativeAngularDifference(360, 360 + 300));
+    assertEquals(179, Util.relativeAngularDifference(0, 181));
+    assertEquals(-170, Util.relativeAngularDifference(0, 170));
+    assertEquals(-90, Util.relativeAngularDifference(270, 360));
+    assertEquals(-90, Util.relativeAngularDifference(270, 0));
   }
 }

--- a/src/test/java/frc/util/UtilTests.java
+++ b/src/test/java/frc/util/UtilTests.java
@@ -30,4 +30,9 @@ public class UtilTests {
     assertFalse(Util.epsilonEquals(2, 2.1, 1e-2));
     assertFalse(Util.epsilonEquals(5, 2, 1));
   }
+
+  @UtilTest
+  public void relativeAngularDifferenceWorks() {
+    assertEquals(0, Util.relativeAngularDifference(100, 100));
+  }
 }

--- a/src/test/java/frc/util/UtilTests.java
+++ b/src/test/java/frc/util/UtilTests.java
@@ -21,8 +21,8 @@ public class UtilTests {
 
   @UtilTest
   public void relativeAngularDifferenceZerosOnEquivalent() {
-    assertEquals(0, Util.relativeAngularDifference(100, 100));
-    assertEquals(0, Util.relativeAngularDifference(0, 360 * 2));
+    assertEquals(0, Util.relativeAngularDifference(100, 100), 1e-9);
+    assertEquals(0, Util.relativeAngularDifference(0, 360 * 2), 1e-9);
   }
 
   @UtilTest

--- a/src/test/java/frc/util/UtilTests.java
+++ b/src/test/java/frc/util/UtilTests.java
@@ -27,9 +27,12 @@ public class UtilTests {
 
   @UtilTest
   public void relativeAngularDifferenceTakesShortestPath() {
-    assertEquals(-100, Util.relativeAngularDifference(360, 360 + 100));
-    assertEquals(60, Util.relativeAngularDifference(360, 360 + 300));
-    assertEquals(179, Util.relativeAngularDifference(0, 181));
-    assertEquals(-170, Util.relativeAngularDifference(0, 170));
+    assertEquals(100, Util.relativeAngularDifference(0, 100));
+    assertEquals(100, Util.relativeAngularDifference(360, 360 + 100));
+    assertEquals(-60, Util.relativeAngularDifference(360, 360 + 300));
+    assertEquals(-179, Util.relativeAngularDifference(0, 181));
+    assertEquals(170, Util.relativeAngularDifference(0, 170));
+    assertEquals(90, Util.relativeAngularDifference(270, 360));
+    assertEquals(90, Util.relativeAngularDifference(270, 0));
   }
 }


### PR DESCRIPTION
this pr adds rotation command, and binds it to the ``abxy`` cluster, with a layer on right shoulder button to switch between field and robot oriented. 

It also adds a command to kill anything drivebase related with a stick click, by running an instantaneous command requiring the drivebase. This lets a driver abort an out of control robot.

This pid is not perfectly tuned, but it can't be until robot assembly is closer to final. 

The layer object is pretty simple, but allows a button to be joined with another button.

Drivebase subsystem gained a number of features, like knowing its rotational velocity. 

Everything I identified as being unit testable has unit tests - swerve remains next to impossible to unit test.